### PR TITLE
Use new response model for importing products

### DIFF
--- a/app/services/workarea/orderbot/filters.rb
+++ b/app/services/workarea/orderbot/filters.rb
@@ -1,0 +1,33 @@
+module Workarea
+  module Orderbot
+    module Filters
+      def add_filter_values(filters, new_filter)
+        key = new_filter.keys.first
+        val = new_filter[key]
+
+        if filters.key?(key)
+          filters[key] << val
+          filters[key] = filters[key].uniq
+         else
+
+          filters[key] = [val]
+        end
+        filters
+      end
+
+      def first_variable
+        return {} unless product_details[:first_variable].present? && product_details[:first_variable][:group].present?
+        {
+         product_details[:first_variable][:group] => product_details[:first_variable][:value]
+        }.compact
+      end
+
+      def second_variable
+        return {} unless product_details[:second_variable].present? && product_details[:second_variable][:group].present?
+        {
+         product_details[:second_variable][:group] => product_details[:second_variable][:value]
+        }.compact
+      end
+    end
+  end
+end

--- a/app/workers/workarea/orderbot/product_importer.rb
+++ b/app/workers/workarea/orderbot/product_importer.rb
@@ -11,12 +11,11 @@ module Workarea
           last_import = options[:from_updated_on] || last_imported_at
 
           attrs = {
-            response_model: "catalog",
+            response_model: "integration",
             sort_by: "LastUpdatedOn"
           }.merge!(product_filters)
 
           response = gateway.get_products(attrs)
-
           write_products(response.body, last_import)
 
           if response.total_pages.to_i > 1
@@ -29,7 +28,6 @@ module Workarea
               count = count + 1
             end
           end
-
           # import the ob parent products - Top level workarea prodcuts
           Orderbot::Product::ImportParentProducts.new.perform
 
@@ -42,7 +40,7 @@ module Workarea
 
       def write_products(products, last_update_threshold)
         products.each do | product_data|
-          next if Time.parse(product_data["last_updated"]).iso8601 < last_update_threshold.in_time_zone(Workarea.config.orderbot_api_timezone).iso8601
+          next if Time.parse(product_data["updated_on"]).iso8601 < last_update_threshold.in_time_zone(Workarea.config.orderbot_api_timezone).iso8601
 
           parent_product = product_data["parent_id"] == 0
           parent_product_id = product_data["parent_id"]

--- a/lib/workarea/orderbot/authentication.rb
+++ b/lib/workarea/orderbot/authentication.rb
@@ -11,11 +11,13 @@ module Workarea
       private
 
       def get_token
-        conn = Faraday.new(url: rest_endpoint)
-        conn.basic_auth(api_user_name, api_password)
-        conn.get do |req|
-          req.url '/accesstoken'
-          req.headers['Content-Type'] = 'application/json'
+        Rails.cache.fetch(token_cache_key, expires_in: 5.minutes) do
+          conn = Faraday.new(url: rest_endpoint)
+          conn.basic_auth(api_user_name, api_password)
+          conn.get do |req|
+            req.url '/accesstoken'
+            req.headers['Content-Type'] = 'application/json'
+          end
         end
       end
 
@@ -25,6 +27,10 @@ module Workarea
 
       def api_password
         options[:api_password]
+      end
+
+      def token_cache_key
+        Digest::MD5.hexdigest "#{api_user_name}#{api_password}"
       end
     end
   end

--- a/lib/workarea/orderbot/bogus_gateway.rb
+++ b/lib/workarea/orderbot/bogus_gateway.rb
@@ -5,7 +5,11 @@ module Workarea
       end
 
       def get_products(attrs = {})
-        Response.new(response(get_products_response))
+        if attrs[:response_model] == 'CustomField'
+          Response.new(response(get_products_custom_field_response))
+        else
+          Response.new(response(get_products_response))
+        end
       end
 
       def get_inventory(attrs = {})
@@ -31,119 +35,309 @@ module Workarea
         response.get("/orders/createorder")
       end
 
+      def get_products_custom_field_response
+        [
+          {
+          product_id: 123456,
+          custom_fields: [
+              {
+                  name: "Product Batch",
+                  value: "123"
+              },
+              {
+                  name: "Dye Type",
+                  value: "abc"
+              },
+              {
+                  name: "Grade",
+                  value: "F minus"
+              },
+              {
+                  name: "MFG Color",
+                  value: "baby boi blue"
+              }
+            ]
+          }
+        ]
+      end
+
+
       def get_products_response
         [
           {
-            product_id: 3647523,
-            name: "iPhone X",
-            sku: nil,
-            upc: "7475876093756837",
-            active: true,
-            taxable: true,
-            base_price: 0,
-            orderguide_price: nil,
-            units_of_measure: "Each",
-            weight: 1,
-            shipping_unit_of_measure: "Lbs",
-            has_children: true,
-            parent_id: 0,
-            class_type: "DR-Compoment",
-            group_id: 32930,
-            group: "Apple ",
-            category_id: 7717,
-            category: "Phones",
-            first_variable_value: nil,
-            second_variable_value: nil,
-            descriptive_title: nil,
-            description: "A refurbed IphoneX",
-            other_info: nil,
-            creation_date: nil,
-            last_updated: 5.minutes.ago,
-            updated_by: 205306
-          },
-          {
-            product_id: 3647524,
-            name: "iPhone X Rose",
-            sku: "applsku1",
-            upc: "7475876093756837",
-            active: true,
-            taxable: true,
-            base_price: 799,
-            orderguide_price: nil,
-            units_of_measure: "Each",
-            weight: 1,
-            shipping_unit_of_measure: "Lbs",
-            has_children: true,
-            parent_id: 3647523,
-            class_type: "DR-Compoment",
-            group_id: 32930,
-            group: "Apple ",
-            category_id: 7717,
-            category: "Phones",
-            first_variable_value: "rose",
-            second_variable_value: "metal",
-            descriptive_title: nil,
-            description: nil,
-            other_info: nil,
-            creation_date: nil,
-            last_updated: 5.minutes.ago,
-            updated_by: 205306
-          },
-          {
-            product_id: 3647525,
-            name: "iPhone X Black",
-            sku: "applsku2",
-            upc: "74758760945545",
-            active: true,
-            taxable: true,
-            base_price: 899,
-            orderguide_price: nil,
-            units_of_measure: "Each",
-            weight: 1,
-            shipping_unit_of_measure: "Lbs",
-            has_children: true,
-            parent_id: 3647523,
-            class_type: "DR-Compoment",
-            group_id: 32930,
-            group: "Apple ",
-            category_id: 7717,
-            category: "Phones",
-            first_variable_value: "black",
-            second_variable_value: "metal",
-            descriptive_title: nil,
-            description: nil,
-            other_info: nil,
-            creation_date: nil,
-            last_updated: 5.minutes.ago,
-            updated_by: 205306
-          },
-          {
-            product_id: 43355343243,
-            name: "Google Pixel 4",
-            sku: "googlepixel4",
-            upc: "74758760945545",
-            active: true,
-            taxable: true,
-            base_price: 899,
-            orderguide_price: nil,
-            units_of_measure: "Each",
-            weight: 1,
-            shipping_unit_of_measure: "Lbs",
+            category: "Electronics",
+            group: "Phone",
+            product_id: 3212905,
+            sku: "APP0008",
+            name: "iPhone 6M Pink Soft",
             has_children: false,
+            parent_id: 2548672,
+            parent_sku: "APP0001",
+            measurement_unit: "Each",
+            taxable: true,
+            gst_only: false,
+            first_variable: {
+                group: "Colour",
+                type: "Phone",
+                value: "Pink"
+                },
+            second_variable: {
+                group: "Texture",
+                type: "Density",
+                value: "Soft"
+                },
+            description: "",
+            other_important_info: "",
+            upc: "",
+            active: true,
+            reference_product: nil,
+            base_price: 600,
+            order_in_multiples: 1,
+            shipping_weight: 2,
+            shipping_weight_measurement_unit: "Oz",
+            apply_shipping_fee: true,
+            location: "",
+            maximum_commission_rate: 0,
+            export_hts: "",
+            country: nil,
+            descriptive_title: "",
+            csr_description: "",
+            meta_keywords: "",
+            workarea_info: {
+                template: "",
+                purchase_start_date: nil,
+                purchase_end_date: nil
+                },
+            shopify_info: {
+                published_scope: "none",
+                inventory_management: false
+                },
+            shipping_length: nil,
+            shipping_height: nil,
+            shipping_width: nil,
+            digital: false,
+            created_on: "2018-07-04T13:53:12.133",
+            updated_on: 1.day.ago
+          },
+          {
+            category: "Electronics",
+            group: "Phone",
+            product_id: 3212904,
+            sku: "APP0009",
+            name: "iPhone 6M Pink HD",
+            has_children: false,
+            parent_id: 2548672,
+            parent_sku: "APP0001",
+            measurement_unit: "Each",
+            taxable: true,
+            gst_only: false,
+            first_variable: {
+                group: "Colour",
+                type: "Phone",
+                value: "Pink"
+                },
+            second_variable: {
+                group: "Texture",
+                type: "Density",
+                value: "Hard"
+                },
+            description: "",
+            other_important_info: "",
+            upc: "",
+            active: true,
+            reference_product: nil,
+            base_price: 600,
+            order_in_multiples: 1,
+            shipping_weight: 2,
+            shipping_weight_measurement_unit: "Oz",
+            apply_shipping_fee: true,
+            location: "",
+            maximum_commission_rate: 0,
+            export_hts: "",
+            country: nil,
+            descriptive_title: "",
+            csr_description: "",
+            meta_keywords: "",
+            workarea_info: {
+                template: "",
+                purchase_start_date: nil,
+                purchase_end_date: nil
+                },
+            shopify_info: {
+                published_scope: "none",
+                inventory_management: false
+                },
+            shipping_length: nil,
+            shipping_height: nil,
+            shipping_width: nil,
+            digital: false,
+            created_on: "2018-07-04T13:53:11.803",
+            updated_on: 1.day.ago
+          },
+          {
+            category: "Electronics",
+            group: "Phone",
+            product_id: 2855051,
+            sku: "APP0011",
+            name: "iPhone 6M Blue Soft",
+            has_children: false,
+            parent_id: 2548672,
+            parent_sku: "APP0001",
+            measurement_unit: "Each",
+            taxable: true,
+            gst_only: false,
+            first_variable: {
+                group: "Colour",
+                type: "Phone",
+                value: "Blue"
+                },
+            second_variable: {
+                group: "Texture",
+                type: "Density",
+                value: "Soft"
+                },
+            description: "",
+            other_important_info: "",
+            upc: "",
+            active: true,
+            reference_product: nil,
+            base_price: 600,
+            order_in_multiples: 1,
+            shipping_weight: 2,
+            shipping_weight_measurement_unit: "Oz",
+            apply_shipping_fee: true,
+            location: "",
+            maximum_commission_rate: 0,
+            export_hts: "",
+            country: nil,
+            descriptive_title: "",
+            csr_description: "",
+            meta_keywords: "",
+            workarea_info: {
+                template: "",
+                purchase_start_date: nil,
+                purchase_end_date: nil
+                },
+            shopify_info: {
+                published_scope: "none",
+                inventory_management: false
+                },
+            shipping_length: nil,
+            shipping_height: nil,
+            shipping_width: nil,
+            digital: false,
+            created_on: "2017-08-03T16:44:52.04",
+            updated_on: 1.day.ago
+          },
+          {
+            category: "Electronics",
+            group: "Phone",
+            product_id: 2550254,
+            sku: "NK0001",
+            name: "Nokia 150",
+            has_children: true,
             parent_id: 0,
-            class_type: "DR-Compoment",
-            group_id: 32930,
-            group: "Google ",
-            category_id: 7717,
-            category: "Phones",
-            first_variable_value: "black",
-            second_variable_value: "metal",
-            descriptive_title: nil,
-            description: nil,
-            other_info: nil,
-            creation_date: nil,
-            last_updated: 5.minutes.ago,
-            updated_by: 205306
+            parent_sku: nil,
+            measurement_unit: "Each",
+            taxable: true,
+            gst_only: false,
+            first_variable: {
+                group: nil,
+                type: nil,
+                value: nil
+                },
+            second_variable: {
+                group: nil,
+                type: nil,
+                value: nil
+                },
+            description: "",
+            other_important_info: "",
+            upc: "NK001001",
+            active: true,
+            reference_product: nil,
+            base_price: 650,
+            order_in_multiples: 1,
+            shipping_weight: 1,
+            shipping_weight_measurement_unit: "Lbs",
+            apply_shipping_fee: true,
+            location: "",
+            maximum_commission_rate: 8,
+            export_hts: "",
+            country: nil,
+            descriptive_title: "",
+            csr_description: "",
+            meta_keywords: "",
+            workarea_info: {
+                template: "",
+                purchase_start_date: nil,
+                purchase_end_date: nil
+                },
+            shopify_info: {
+                published_scope: "none",
+                inventory_management: nil
+                },
+            shipping_length: nil,
+            shipping_height: nil,
+            shipping_width: nil,
+            digital: false,
+            created_on: "2016-12-23T10:36:16.637",
+            updated_on: 1.day.ago
+          },
+          {
+            category: "Electronics",
+            group: "Phone",
+            product_id: 2548672,
+            sku: "APP0001",
+            name: "iPhone 6M",
+            has_children: true,
+            parent_id: 0,
+            parent_sku: nil,
+            measurement_unit: "Each",
+            taxable: true,
+            gst_only: false,
+            first_variable: {
+                group: nil,
+                type: nil,
+                value: nil
+                },
+            second_variable: {
+                group: nil,
+                type: nil,
+                value: nil
+                },
+            description: "",
+            other_important_info: "",
+            upc: "APP001001",
+            active: true,
+            reference_product: nil,
+            base_price: 600,
+            order_in_multiples: 1,
+            shipping_weight: 2,
+            shipping_weight_measurement_unit: "Oz",
+            apply_shipping_fee: true,
+            location: "",
+            maximum_commission_rate: nil,
+            export_hts: "",
+            country: nil,
+            descriptive_title: "",
+            csr_description: "",
+            meta_keywords: "",
+            workarea_info: {
+                template: "",
+                purchase_start_date: nil,
+                purchase_end_date: nil
+                },
+            shopify_info: {
+                published_scope: "none",
+                inventory_management: nil
+                },
+            shipping_length: nil,
+            shipping_height: nil,
+            shipping_width: nil,
+            digital: false,
+            created_on: "2016-12-21T15:13:30.213",
+            updated_on: 1.day.ago
           }
         ]
       end

--- a/test/services/workarea/orderbot/product/child_product_test.rb
+++ b/test/services/workarea/orderbot/product/child_product_test.rb
@@ -25,6 +25,11 @@ module Workarea
           assert_equal(50.to_m, pricing.sell_price)
 
           assert_equal(16, shipping.weight) # 1lb converted to oz.
+
+          product.reload
+
+          assert_equal(["Red", "Pink"], product.filters["color"])
+          assert_equal(["cotton", "metal"], product.filters["material"])
         end
 
         def test_process_orderguide_price
@@ -73,8 +78,16 @@ module Workarea
             group: "Accessories",
             category_id: 5462,
             category: "Electronics",
-            first_variable_value: nil,
-            second_variable_value: nil,
+            first_variable: {
+              group: "color",
+              type: "Phone",
+              value: "Red"
+            },
+            second_variable: {
+              group: "material",
+              type: "material",
+              value: "cotton"
+            },
             descriptive_title: "",
             description: "Test",
             other_info: "",
@@ -104,8 +117,16 @@ module Workarea
             group: "Accessories",
             category_id: 5462,
             category: "Electronics",
-            first_variable_value: "blue",
-            second_variable_value: "metal",
+            first_variable: {
+              group: "color",
+              type: "Phone",
+              value: "Pink"
+            },
+            second_variable: {
+              group: "material",
+              type: "material",
+              value: "metal"
+            },
             descriptive_title: "",
             description: "Test",
             other_info: "",
@@ -135,8 +156,16 @@ module Workarea
             group: "Accessories",
             category_id: 5462,
             category: "Electronics",
-            first_variable_value: "blue",
-            second_variable_value: "metal",
+            first_variable: {
+              group: "color",
+              type: "Phone",
+              value: "Pink"
+            },
+            second_variable: {
+              group: "material",
+              type: "material",
+              value: "metal"
+            },
             descriptive_title: "",
             description: "Test",
             other_info: "",
@@ -166,8 +195,16 @@ module Workarea
             group: "Accessories",
             category_id: 5462,
             category: "Electronics",
-            first_variable_value: "blue",
-            second_variable_value: "metal",
+            first_variable: {
+              group: "color",
+              type: "Phone",
+              value: "Pink"
+            },
+            second_variable: {
+              group: "material",
+              type: "material",
+              value: "metal"
+            },
             descriptive_title: "",
             description: "Test",
             other_info: "",

--- a/test/services/workarea/orderbot/product/parent_product_test.rb
+++ b/test/services/workarea/orderbot/product/parent_product_test.rb
@@ -12,7 +12,6 @@ module Workarea
           product = Workarea::Catalog::Product.first
           assert_equal("Blue Tooth USB", product.name)
           assert_equal("Test", product.description)
-          assert_equal(5462, product.filters[:category_id])
           assert_equal("Electronics", product.filters[:category])
           assert_equal(["BTUSB001"], product.fetch_detail(:upc))
 
@@ -34,7 +33,6 @@ module Workarea
             class_type: "Sales Items",
             group_id: 20693,
             group: "Accessories",
-            category_id: 5462,
             category: "Electronics",
             first_variable_value: nil,
             second_variable_value: nil,


### PR DESCRIPTION
Product details are now consumed by a second call to the customfield response model. This change also makes use of the "integration" product response model, which exposes the name of custom fields rather than a generic "custom_field_1" 

ORDERBOT-4

no changelog