### PR TITLE
Import prices from orderbot API pricing endpoint.

### DIFF
--- a/app/models/workarea/orderbot/pricing_import_data.rb
+++ b/app/models/workarea/orderbot/pricing_import_data.rb
@@ -1,0 +1,13 @@
+module Workarea
+  module Orderbot
+    class PricingImportData
+      include ApplicationDocument
+
+      field :pricing_data, type: Hash
+      field :order_guide_id, type: String
+
+      index({ created_at: 1 }, { expire_after_seconds: 6.months.seconds.to_i })
+      index({ order_guide_id: 1 })
+    end
+  end
+end

--- a/app/workers/workarea/orderbot/pricing/import_pricing.rb
+++ b/app/workers/workarea/orderbot/pricing/import_pricing.rb
@@ -1,0 +1,42 @@
+module Workarea
+  module Orderbot
+    module Pricing
+      class ImportPricing
+        include Sidekiq::Worker
+
+        def perform
+          Workarea::Orderbot::PricingImportData.each do |sku_price|
+            pricing_data = sku_price.pricing_data.deep_symbolize_keys
+
+            next unless pricing_data[:sku].present?
+            sku = Workarea::Pricing::Sku.find_or_initialize_by(id: pricing_data[:sku])
+
+            original_price = pricing_data[:original_price]
+            price =  pricing_data[:price]
+
+            regular = regular_price(price, original_price)
+            sale = sale_price(price, original_price)
+
+            sku.on_sale = sale.present?
+            sku.prices = [{ regular: regular, sale: sale, on_sale: sale.present? }]
+            sku.save!
+
+            sku_price.delete
+          end
+        end
+
+        private
+
+        def regular_price(price, original_price)
+          return original_price if original_price.present? && original_price > price
+          price
+        end
+
+        def sale_price(price, original_price)
+          return nil if original_price.blank? || original_price == price
+          price
+        end
+      end
+    end
+  end
+end

--- a/app/workers/workarea/orderbot/pricing_importer.rb
+++ b/app/workers/workarea/orderbot/pricing_importer.rb
@@ -1,0 +1,69 @@
+module Workarea
+  module Orderbot
+    class PricingImporter
+      include Sidekiq::Worker
+      sidekiq_options retry: 5
+
+      def perform(options = {})
+        return unless Orderbot.api_configured?
+
+        Orderbot::ImportLog.log('pricing')  do |last_imported_at|
+          last_import = options[:from_updated_on] || last_imported_at
+
+          pricing_filters = {
+            response_model:  "OrderGuideProduct",
+          }
+
+          pricing_response = gateway.get_pricing(pricing_filters)
+
+          raise 'get pricing error' unless  pricing_response.success?
+
+          pricing_records = pricing_response.body
+
+          write_prices(pricing_records, last_import)
+          if pricing_response.total_pages.to_i > 1
+            count = 2
+
+            while count <= pricing_response.total_pages.to_i
+              page_filters = pricing_filters.merge(page: count)
+              response = gateway.get_products(page_filters)
+
+              write_prices(response.body, last_import)
+              count = count + 1
+            end
+          end
+
+          Workarea::Orderbot::Pricing::ImportPricing.new.perform
+        end
+      end
+
+      private
+
+      def gateway
+        Workarea::Orderbot.gateway
+      end
+
+      def write_prices(order_guides, last_update_threshold)
+        order_guides.each do | order_guide|
+
+          order_guide_id = order_guide["order_guide_id"]
+
+          # only import the prices if we care about this order guide ID
+          next if order_guide_id != Workarea.config.default_order_guide_id
+
+          products = order_guide["products"]
+
+          products.each do |product|
+
+            next if product["last_updated_on"].present? && Time.parse(product["last_updated_on"]).iso8601 < last_update_threshold.in_time_zone(Workarea.config.orderbot_api_timezone).iso8601
+
+            Orderbot::PricingImportData.create!(
+              order_guide_id: order_guide_id,
+              pricing_data: product
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/scheduled_jobs.rb
+++ b/config/initializers/scheduled_jobs.rb
@@ -12,3 +12,11 @@ Sidekiq::Cron::Job.create(
   cron: '0 * * * *',
   queue: 'low'
 )
+
+
+Sidekiq::Cron::Job.create(
+  name: 'Workarea::Orderbot::PricingImporter',
+  klass: 'Workarea::Orderbot::PricingImporter',
+  cron: '30 * * * *',
+  queue: 'low'
+)

--- a/lib/workarea/orderbot/bogus_gateway.rb
+++ b/lib/workarea/orderbot/bogus_gateway.rb
@@ -16,6 +16,10 @@ module Workarea
         Response.new(response(get_inventory_response))
       end
 
+      def get_pricing(attrs = {})
+        Response.new(response(get_pricing_response))
+      end
+
       def create_order(attrs = {})
         if attrs.first[:reference_order_id] == "error"
           Response.new(response(create_error_order_response, 400))
@@ -395,6 +399,89 @@ module Workarea
           status: 400,
           traceId: "0HLRMSI1H2BKA:00000001"
         }
+      end
+
+      def get_pricing_response
+        [
+          {
+            effective_date: nil,
+            name: "CAN-REWARDS",
+            order_guide_id: 1,
+            sales_channel_id: 286,
+            version_id: 3187,
+            products: [
+              {
+                force_schedule: nil,
+                last_updated_on: 5.minutes.ago,
+                original_price: 15.0,
+                price: 15.0,
+                product_id: 3592532,
+                sales_end_on: nil,
+                sales_start_on: nil,
+                sku: "SAMEPRICE1"
+              },
+              {
+                force_schedule: nil,
+                last_updated_on: 5.minutes.ago,
+                original_price: nil,
+                price: 20.0,
+                product_id: 3592539,
+                sales_end_on: nil,
+                sales_start_on: nil,
+                sku: "REGULAR1"
+              },
+              {
+                force_schedule: nil,
+                last_updated_on: 5.minutes.ago,
+                original_price: 45.0,
+                price: 30.0,
+                product_id: 3592535,
+                sales_end_on: nil,
+                sales_start_on: nil,
+                sku: "SALE1"
+              }
+            ]
+          },
+          {
+            effective_date: nil,
+            name: "UK-Shopify",
+            order_guide_id: 2,
+            sales_channel_id: 286,
+            version_id: 3177,
+            products: [
+              {
+                force_schedule: nil,
+                last_updated_on: 5.minutes.ago,
+                original_price: nil,
+                price: 570.0,
+                product_id: 2548678,
+                sales_end_on: nil,
+                sales_start_on: nil,
+                sku: "APP0006"
+              },
+              {
+                force_schedule: nil,
+                last_updated_on: 5.minutes.ago,
+                original_price: nil,
+                price: 570.0,
+                product_id: 2855050,
+                sales_end_on: nil,
+                sales_start_on: nil,
+                sku: "APP0010"
+              },
+              {
+                force_schedule: nil,
+                last_updated_on: 5.minutes.ago,
+                original_price: nil,
+                price: 237.5,
+                product_id: 3081908,
+                sales_end_on: nil,
+                sales_start_on: nil,
+                sku: "AMP0101"
+              }
+            ]
+          }
+        ]
       end
     end
   end

--- a/lib/workarea/orderbot/gateway.rb
+++ b/lib/workarea/orderbot/gateway.rb
@@ -27,6 +27,15 @@ module Workarea
         Orderbot::Response.new(response)
       end
 
+      def get_pricing(attrs = {})
+        response = connection.get do |req|
+          req.options.params_encoder = Faraday::FlatParamsEncoder
+          req.url "pricing"
+          req.params = attrs
+        end
+        Orderbot::Response.new(response)
+      end
+
       def create_order(attrs = {})
         response = connection.post do |req|
           req.url "orders"

--- a/test/workers/workarea/orderbot/pricing/import_pricing_test.rb
+++ b/test/workers/workarea/orderbot/pricing/import_pricing_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+module Workarea
+  module Orderbot
+    class Inventory::ImportInventoryTest < TestCase
+      def test_import_price
+        pricing_data = {
+          force_schedule: nil,
+          last_updated_on: 5.minutes.ago,
+          original_price: 15.0,
+          price: 15.0,
+          product_id: 3592532,
+          sales_end_on: nil,
+          sales_start_on: nil,
+          sku: "SAMEPRICE1"
+        }
+
+        Orderbot::PricingImportData.create!(
+          order_guide_id: 1,
+          pricing_data: pricing_data
+        )
+
+        Workarea::Orderbot::Pricing::ImportPricing.new.perform
+        sku = Workarea::Pricing::Sku.first
+        price = sku.prices.first
+
+        assert_equal(15.to_m, price.regular)
+        refute(price.sale.present?)
+        refute(price.on_sale?)
+        refute(sku.on_sale?)
+      end
+
+      def test_import_sales_price
+        pricing_data = {
+          force_schedule: nil,
+          last_updated_on: 5.minutes.ago,
+          original_price: 15.0,
+          price: 10.0,
+          product_id: 3592532,
+          sales_end_on: nil,
+          sales_start_on: nil,
+          sku: "SALEPRICE1"
+        }
+
+        Orderbot::PricingImportData.create!(
+          order_guide_id: 1,
+          pricing_data: pricing_data
+        )
+
+        Workarea::Orderbot::Pricing::ImportPricing.new.perform
+        sku = Workarea::Pricing::Sku.first
+        price = sku.prices.first
+
+        assert_equal(15.to_m, price.regular)
+        assert_equal(10.to_m, price.sale)
+        assert(price.on_sale?)
+        assert(sku.on_sale?)
+      end
+    end
+  end
+end

--- a/test/workers/workarea/orderbot/pricing_importer_test.rb
+++ b/test/workers/workarea/orderbot/pricing_importer_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+module Workarea
+  class Orderbot::PricingImporterTest < TestCase
+    def test_pricing_import_data
+      Workarea.config.orderbot_api_email_address = "test@workarea.com"
+      Workarea.config.orderbot_api_password = "foobar"
+      Workarea.config.default_order_guide_id = 1
+
+      assert_equal(0, Workarea::Orderbot::ImportLog.count)
+
+      Workarea::Orderbot::PricingImporter.new.perform # uses data from Workarea::Orderbot::Bogusgateway
+
+      assert_equal(3, Workarea::Pricing::Sku.count)
+
+      sale_sku = Workarea::Pricing::Sku.find('SALE1')
+      assert(sale_sku.on_sale?)
+
+      price = sale_sku.prices.first
+
+      assert_equal(45.00.to_m, price.regular)
+      assert_equal(30.00.to_m, price.sale)
+
+      log = Workarea::Orderbot::ImportLog.where(importer: "pricing").first
+      assert(log.started_at.present?)
+      assert(log.finished_at.present?)
+    end
+  end
+end


### PR DESCRIPTION
Store prices in a mongoid collection for processing. Only
prices that have been updated since the last import and have the
configured order guide ID will be imported

no changelog

ORDERBOT-5